### PR TITLE
adding cli arg to configure mailbox name

### DIFF
--- a/cmd/hatchet/hatchet.go
+++ b/cmd/hatchet/hatchet.go
@@ -69,6 +69,7 @@ func main() {
 						"imap-username": c.String("imap-username"),
 						"imap-password": c.String("imap-password"),
 						"output-path":   c.String("output-path"),
+						"mailbox-name":  c.String("mailbox-name"),
 					})
 					if err != nil {
 						return err
@@ -100,6 +101,12 @@ func main() {
 						Name:  "output-path",
 						Value: "sender_report.csv",
 						Usage: "Path to output file",
+					},
+
+					&cli.StringFlag{
+						Name:  "mailbox-name",
+						Value: "[Gmail]/All Mail",
+						Usage: "Name of your mailbox",
 					},
 
 					&cli.BoolFlag{

--- a/pkg/engine.go
+++ b/pkg/engine.go
@@ -28,8 +28,9 @@ type EmailEngine struct {
 	logger *logrus.Entry
 	client *client.Client
 
-	reportPath string
-	report     map[string]*model.SenderReport
+	reportPath  string
+	mailboxName string
+	report      map[string]*model.SenderReport
 }
 
 func New(logger *logrus.Entry, config map[string]string) (EmailEngine, error) {
@@ -39,6 +40,7 @@ func New(logger *logrus.Entry, config map[string]string) (EmailEngine, error) {
 	emailEngine.logger = logger
 	emailEngine.report = map[string]*model.SenderReport{}
 	emailEngine.reportPath = config["output-path"]
+	emailEngine.mailboxName = config["mailbox-name"]
 
 	emailEngine.logger.Infoln("Connecting to server...")
 
@@ -75,7 +77,7 @@ func (ee *EmailEngine) Start() error {
 	for {
 		// get latest mailbox information
 		//https://bitmapcake.blogspot.com/2018/07/gmail-mailbox-names-for-imap-connections.html
-		mbox, err := ee.client.Select("[Gmail]/All Mail", false)
+		mbox, err := ee.client.Select(ee.mailboxName, false)
 		if err != nil {
 			ee.logger.Fatal(err)
 		}


### PR DESCRIPTION
Adds support for non-gmail imap accounts

```sh
./hatchet-darwin-arm64 report \
  --imap-hostname="" \
  --imap-username="" \
  --imap-password="" \
  --mailbox-name="Inbox"
```

The default is still `[Gmail]/All Mail`